### PR TITLE
[Precogs Alert] Hard-coded Secret (Flask secret_key in source) detected (CWE-798, Risk: Critical)

### DIFF
--- a/flask_webgoat/__init__.py
+++ b/flask_webgoat/__init__.py
@@ -18,23 +18,34 @@ def query_db(query, args=(), one=False, commit=False):
 
 
 def create_app():
+    import os
+    import sqlite3
+    from pathlib import Path
+    from werkzeug.security import generate_password_hash
+
     app = Flask(__name__)
-    app.secret_key = "aeZ1iwoh2ree2mo0Eereireong4baitixaixu5Ee"
+    # PRECOGS_FIX: Do not hard-code secrets; read from environment and fall back to a securely generated key
+    secret = os.environ.get("FLASK_SECRET_KEY")
+    if secret:
+        app.secret_key = secret
+    else:
+        # Generate a strong ephemeral key to avoid embedding secrets in source. For production, require FLASK_SECRET_KEY.
+        app.secret_key = os.urandom(32)
 
     db_path = Path(DB_FILENAME)
     if db_path.exists():
         db_path.unlink()
 
-    conn = sqlite3.connect(DB_FILENAME)
-    create_table_query = """CREATE TABLE IF NOT EXISTS user
-    (id INTEGER PRIMARY KEY, username TEXT, password TEXT, access_level INTEGER)"""
-    conn.execute(create_table_query)
+    with sqlite3.connect(DB_FILENAME) as conn:
+        create_table_query = """CREATE TABLE IF NOT EXISTS user
+        (id INTEGER PRIMARY KEY, username TEXT, password TEXT, access_level INTEGER)"""
+        conn.execute(create_table_query)
 
-    insert_admin_query = """INSERT INTO user (id, username, password, access_level)
-    VALUES (1, 'admin', 'maximumentropy', 0)"""
-    conn.execute(insert_admin_query)
-    conn.commit()
-    conn.close()
+        # PRECOGS_FIX: Store admin password as a secure hash instead of plaintext
+        hashed = generate_password_hash("maximumentropy")
+        insert_admin_query = "INSERT INTO user (id, username, password, access_level) VALUES (1, ?, ?, ?)"
+        conn.execute(insert_admin_query, ("admin", hashed, 0))
+        conn.commit()
 
     with app.app_context():
         from . import actions


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `shiftleft-python-demo/flask_webgoat/__init__.py`
  - **Vulnerability Type:** Hard-coded Secret (Flask secret_key in source)
  - **Risk Level:** Critical
  
  **Explanation:**  
  **Primary: Hard-coded Secret (Flask secret_key in source) (CWE-798)** — The Flask application's secret_key is hard-coded directly into source code. If the repository is shared or leaked (or if multiple deployments use the same code), the secret is exposed and can be used to forge session cookies or tamper with signed data. Secret keys should be provisioned from secure configuration, environment variables, or a secrets manager, not embedded in code.

**Also found:** **Cleartext Storage of Sensitive Information (Plaintext Password in DB) (CWE-312)** — The code inserts an administrator account with a plaintext password into the database. Storing passwords in cleartext allows anyone with database access (or backups, log exports, leaked DB files) to read real passwords and use them to compromise accounts. Passwords must be hashed with a secure, adaptive algorithm (e.g., bcrypt, PBKDF2, scrypt, Argon2) before storage.
  
  Please review and address the issue accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now supports configuring the secret key via the `FLASK_SECRET_KEY` environment variable for enhanced deployment flexibility.

* **Bug Fixes**
  * Improved security for password credential storage in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->